### PR TITLE
Add README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Grega Play
+
+This repository contains the code for **Grega Play**, an application for creating short collaborative videos to celebrate special events.
+
+## Directory overview
+
+- **frontend/** – React application built with Vite. It handles the user interface and authentication. Detailed instructions are available in [frontend/README.md](frontend/README.md).
+- **backend/** – Node.js/Express server used for video processing tasks.
+- **supabase/** – Supabase configuration files and edge functions.
+- **email/** – HTML email templates.
+- **sql/** – SQL scripts for initializing the database schema.
+
+## Quick start
+
+This project requires [Node.js](https://nodejs.org/) and [pnpm](https://pnpm.io/) installed.
+
+### Frontend
+
+```bash
+cd frontend
+pnpm install
+pnpm run dev
+```
+
+### Backend
+
+```bash
+cd backend
+pnpm install
+pnpm run start
+```
+
+For configuration details and more usage information, refer to the documentation in [frontend/README.md](frontend/README.md).
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for the full text.


### PR DESCRIPTION
## Summary
- add root README summarizing repository
- include MIT License to match frontend README

## Testing
- `pnpm -v` *(fails: proxy response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68890c1a245c8331a10a6472875cb855